### PR TITLE
Suggested tweaks to --version

### DIFF
--- a/source/rust_verify/src/main.rs
+++ b/source/rust_verify/src/main.rs
@@ -1,6 +1,6 @@
 #![feature(rustc_private)]
 
-use rust_verify::util::{verus_build_profile, VerusBuildProfile};
+use rust_verify::util::{verus_build_info, VerusBuildProfile};
 
 extern crate rustc_driver; // TODO(main_new) can we remove this?
 
@@ -76,10 +76,28 @@ pub fn main() {
         false
     };
 
-    let profile = verus_build_profile();
+    let build_info = verus_build_info();
+
+    let total_time_0 = std::time::Instant::now();
+
+    let _ = os_setup();
+    verus_rustc_driver::init_env_logger("RUSTVERIFY_LOG");
+
+    let mut args = if build_test_mode { internal_args } else { std::env::args() };
+    let program = if build_test_mode { internal_program } else { args.next().unwrap() };
+    let (our_args, rustc_args) = rust_verify::config::parse_args(&program, args);
+
+    if our_args.version {
+        println!("Verus");
+        println!("  Platform: {}_{}", std::env::consts::OS, std::env::consts::ARCH);
+        println!("  Version: {}", build_info.version);
+        println!("  Profile: {}", build_info.profile.to_string());
+
+        return;
+    }
 
     if !build_test_mode {
-        match profile {
+        match build_info.profile {
             VerusBuildProfile::Debug => eprintln!(
                 "warning: verus was compiled in debug mode, which will result in worse performance"
             ),
@@ -90,25 +108,7 @@ pub fn main() {
         }
     }
 
-    let total_time_0 = std::time::Instant::now();
-
-    let _ = os_setup();
-    verus_rustc_driver::init_env_logger("RUSTVERIFY_LOG");
-
-    let mut args = if build_test_mode { internal_args } else { std::env::args() };
-    let program = if build_test_mode { internal_program } else { args.next().unwrap() };
-    let (our_args, rustc_args) = rust_verify::config::parse_args(&program, args);
     let pervasive_path = our_args.pervasive_path.clone();
-
-    if our_args.version {
-        println!("Verus");
-        println!("  Platform: {}_{}", std::env::consts::OS, std::env::consts::ARCH);
-
-        let version = option_env!("VERUS_BUILD_VERSION").unwrap_or("Unknown");
-        println!("  Version: {}", version);
-
-        return;
-    }
 
     std::env::set_var("RUSTC_BOOTSTRAP", "1");
 
@@ -166,7 +166,8 @@ pub fn main() {
             }
             Some(times)
         } else {
-            println!("verus-build-profile: {}", profile.to_string());
+            println!("verus-build-profile: {}", build_info.profile.to_string());
+            println!("verus-build-version: {}", build_info.version.to_string());
             println!("total-time:      {:>10} ms", total_time.as_millis());
             println!("    rust-time:       {:>10} ms", rust.as_millis());
             println!("        init-and-types:  {:>10} ms", rust_init.as_millis());
@@ -212,7 +213,11 @@ pub fn main() {
         }
         out.insert(
             "verus-build-profile".to_string(),
-            serde_json::Value::String(profile.to_string()),
+            serde_json::Value::String(build_info.profile.to_string()),
+        );
+        out.insert(
+            "verus-build-version".to_string(),
+            serde_json::Value::String(build_info.version.to_string()),
         );
         println!("{}", serde_json::ser::to_string_pretty(&out).expect("invalid json"));
     }

--- a/source/rust_verify/src/util.rs
+++ b/source/rust_verify/src/util.rs
@@ -105,7 +105,7 @@ impl std::fmt::Display for VerusBuildProfile {
     }
 }
 
-pub const fn verus_build_profile() -> VerusBuildProfile {
+const fn verus_build_profile() -> VerusBuildProfile {
     let profile = option_env!("VARGO_BUILD_PROFILE");
     match profile {
         Some(p) => {
@@ -119,6 +119,20 @@ pub const fn verus_build_profile() -> VerusBuildProfile {
         }
         None => VerusBuildProfile::Unknown,
     }
+}
+
+pub struct VerusBuildInfo {
+    pub profile: VerusBuildProfile,
+    pub version: &'static str,
+}
+
+pub const fn verus_build_info() -> VerusBuildInfo {
+    let profile = verus_build_profile();
+    let version = match option_env!("VARGO_BUILD_VERSION") {
+        Some(version) => version,
+        None => "Unknown",
+    };
+    VerusBuildInfo { profile, version }
 }
 
 // ==================================================================================================

--- a/tools/vargo/src/main.rs
+++ b/tools/vargo/src/main.rs
@@ -140,10 +140,6 @@ const Z3_FILE_NAME: &str = if cfg!(target_os = "windows") {
 };
 
 fn run() -> Result<(), String> {
-    if let Some(version_info) = util::version_info() {
-        std::env::set_var("VERUS_BUILD_VERSION", version_info);
-    }
-
     let _vargo_nest = {
         let vargo_nest = std::env::var("VARGO_NEST")
             .ok()
@@ -174,17 +170,26 @@ fn run() -> Result<(), String> {
     let mut args_bucket = args.clone();
     let in_nextest = std::env::var("VARGO_IN_NEXTEST").is_ok();
 
-    let rust_toolchain_toml = toml::from_str::<toml::Value>(
-        &std::fs::read_to_string(std::path::Path::new("..").join("rust-toolchain.toml")).map_err(
-            |x| {
+    let (repo_root, rust_toolchain_toml) = {
+        let current_dir = std::env::current_dir()
+            .map_err(|x| format!("could not obtain the current directory ({})", x))?;
+        let repo_root = current_dir
+            .parent()
+            .ok_or(format!(
+                "current dir does not have a parent\nrun vargo in `source`"
+            ))?
+            .to_owned();
+        let rust_toolchain_toml = toml::from_str::<toml::Value>(
+            &std::fs::read_to_string(repo_root.join("rust-toolchain.toml")).map_err(|x| {
                 format!(
                     "could not read rust-toolchain.toml ({})\nrun vargo in `source`",
                     x
                 )
-            },
-        )?,
-    )
-    .map_err(|x| format!("could not parse Cargo.toml ({})\nrun vargo in `source`", x))?;
+            })?,
+        )
+        .map_err(|x| format!("could not parse Cargo.toml ({})\nrun vargo in `source`", x))?;
+        (repo_root, rust_toolchain_toml)
+    };
     let rust_toolchain_toml_channel = rust_toolchain_toml.get("toolchain").and_then(|t| t.get("channel"))
         .and_then(|t| if let toml::Value::String(s) = t { Some(s) } else { None })
         .ok_or(
@@ -291,6 +296,15 @@ fn run() -> Result<(), String> {
         .position(|x| x.as_str() == "--release" || x.as_str() == "-r")
         .map(|p| args_bucket.remove(p))
         .is_some();
+
+    match util::version_info(&repo_root) {
+        Ok(version_info) => std::env::set_var("VARGO_BUILD_VERSION", version_info),
+        Err(err) => {
+            warn(
+                format!("could not obtain version info from git, this will result in a binary with an unknown version: {}", err).as_str()
+            )
+        }
+    }
 
     std::env::set_var(
         "VARGO_BUILD_PROFILE",


### PR DESCRIPTION
* make the parsing of git's output a bit more resistant to unexpected situations (e.g. non-zero status codes)
* transfer the version alongside the build profile (VARGO_BUILD_VERSION), and grab it in the same code path as the build profile
* with --version, don't print the warning that verus was built in debug mode
* print the profile alongside the version and platform in --version
* add the version to the output produced by --time
* use the full sha to avoid ambiguity in case of collisions